### PR TITLE
Include the shared invite link to ba-st.slack.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The documentation in this repository is licensed under [CC BY-SA 4.0](http://cre
 
 We hangout on [Slack](https://ba-st.slack.com/) where we discuss everything related to the ecosystem.
 
-You can request an invite to [gcotelli](https://github.com/gcotelli) , [fortizpenaloza](https://github.com/fortizpenaloza) or any other admin.
+You can [join by following this link](https://join.slack.com/t/ba-st/shared_invite/zt-27v8f36pt-DhBLgnYMsE~i8~Phm~z6UA), or request an invite to [gcotelli](https://github.com/gcotelli) , [fortizpenaloza](https://github.com/fortizpenaloza) or any other admin.
 
 ## Blog
 


### PR DESCRIPTION
Provide the means to join ba-st.slack.com directly, but keep the admins contacts in case it expires.